### PR TITLE
Add a visibility toggle for user's email

### DIFF
--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml
@@ -39,7 +39,11 @@
                     <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}" Foreground="{ThemeResource ApplicationSecondaryForegroundThemeBrush}">
                         <Run Foreground="{ThemeResource ApplicationForegroundThemeBrush}" Text="{Binding User.Username, Mode=OneWay}"/>#<Run Text="{Binding User.Discriminator, Mode=OneWay}"/>
                     </TextBlock>
-                    <TextBlock Text="{Binding User.Email}"/>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock x:Name="email" VerticalAlignment="Center"/>
+                        <HyperlinkButton Name="EmailRevealButton" x:Uid="/AccountsSettingsPage/EmailRevealButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Visible" Click="EmailRevealButton_Click"/>
+                        <HyperlinkButton Name="EmailHideButton" x:Uid="/AccountsSettingsPage/EmailHideButton" Style="{ThemeResource TextBlockButtonStyle}" VerticalAlignment="Center" Padding="2" Visibility="Collapsed" Click="EmailHideButton_Click"/>
+                    </StackPanel>
                 </StackPanel>
             </Grid>
             <Button Grid.Column="1" Style="{ThemeResource IconButtonStyle}" VerticalAlignment="Top" Content="&#xE70F;" />

--- a/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml.cs
+++ b/Unicord.Universal/Pages/Settings/AccountsSettingsPage.xaml.cs
@@ -17,6 +17,8 @@ namespace Unicord.Universal.Pages.Settings
         {
             InitializeComponent();
 
+            email.Text = GetHiddenEmail(App.Discord.CurrentUser.Email);
+
             MarkdownDocument.KnownSchemes.Add("ms-people");
 
             syncContactsSwitch.IsOn = App.RoamingSettings.Read(SYNC_CONTACTS, true);
@@ -58,6 +60,29 @@ namespace Unicord.Universal.Pages.Settings
         private async void OnMarkdownLinkClicked(object sender, LinkClickedEventArgs e)
         {
             await Launcher.LaunchUriAsync(new Uri(e.Link));
+        }
+
+        private void EmailRevealButton_Click(object sender, RoutedEventArgs e)
+        {
+            email.Text = App.Discord.CurrentUser.Email;
+
+            EmailRevealButton.Visibility = Visibility.Collapsed;
+            EmailHideButton.Visibility = Visibility.Visible;
+        }
+
+        private void EmailHideButton_Click(object sender, RoutedEventArgs e)
+        {
+            email.Text = GetHiddenEmail(App.Discord.CurrentUser.Email);
+
+            EmailHideButton.Visibility = Visibility.Collapsed;
+            EmailRevealButton.Visibility = Visibility.Visible;
+        }
+
+        private string GetHiddenEmail(string email)
+        {
+            string domain = email.Split('@')[1];
+
+            return $"*****@{domain}";
         }
     }
 }

--- a/Unicord.Universal/Resources/en-GB/AccountsSettingsPage.resw
+++ b/Unicord.Universal/Resources/en-GB/AccountsSettingsPage.resw
@@ -123,6 +123,12 @@
   <data name="ContactsUnavailable.Text" xml:space="preserve">
     <value>Contact syncing is not available on this device.</value>
   </data>
+  <data name="EmailHideButton.Content" xml:space="preserve">
+    <value>Hide</value>
+  </data>
+  <data name="EmailRevealButton.Content" xml:space="preserve">
+    <value>Reveal</value>
+  </data>
   <data name="FriendsText.Text" xml:space="preserve">
     <value>Friends</value>
   </data>


### PR DESCRIPTION
This adds a hide/reveal toggle to the user's email in the Account Settings page.